### PR TITLE
Fix install path for kp files

### DIFF
--- a/build/kp.spec
+++ b/build/kp.spec
@@ -2,7 +2,7 @@
 
 Name:           kp
 Version:        0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Korora Packaging Tool
 License:        GPLv3
 URL:            https://kororaproject.org/
@@ -39,5 +39,7 @@ cp -r lib/* %{buildroot}%{_datadir}/share/%{name}/
 %{_datadir}/kp
 
 %changelog
+* Wed Jul 18 2018 Jim Dean <JMiahMan@gmail.com> 0.1-2
+
 * Mon Jan 11 2016 Jim Dean <ozjd@kororaproject.org> 0.1-1
 - Initial spec. 

--- a/build/kp.spec
+++ b/build/kp.spec
@@ -39,7 +39,8 @@ cp -r lib/* %{buildroot}%{_datadir}/share/%{name}/
 %{_datadir}/kp
 
 %changelog
-* Wed Jul 18 2018 Jim Dean <JMiahMan@gmail.com> 0.1-2
+* Wed Jul 18 2018 JMiahMan <JMiahMan@gmail.com> 0.1-2
+- Bump rel for spec fix
 
 * Mon Jan 11 2016 Jim Dean <ozjd@kororaproject.org> 0.1-1
 - Initial spec. 

--- a/build/kp.spec
+++ b/build/kp.spec
@@ -36,7 +36,7 @@ cp -r lib/* %{buildroot}%{_datadir}/share/%{name}/
 %files
 %doc COPYING
 %{_bindir}/kp
-%{_datadir}/share/kp
+%{_datadir}/kp
 
 %changelog
 * Mon Jan 11 2016 Jim Dean <ozjd@kororaproject.org> 0.1-1


### PR DESCRIPTION
The %{_datadir} macro contains "/usr/share/" the extra share in the path "%{_datadir}/share/kp" causes the files to be installed in unexpected location /usr/share/share/kp